### PR TITLE
Fix case of include

### DIFF
--- a/src/iocontrol.h
+++ b/src/iocontrol.h
@@ -5,7 +5,7 @@
 #include <OneWire.h>
 #include <DallasTemperature.h>
 #include <pinmap.h>
-#include <LEDcontroller.h>
+#include <LEDController.h>
 
 #define PCA9555_ADRESS_1 0x20
 #define PCA9555_ADRESS_2 0x24


### PR DESCRIPTION
Under linux the include should be
#include <LED**C**ontroller.h>
Otherwise the header is not found.